### PR TITLE
clean up our environment in the binstub

### DIFF
--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -29,6 +29,10 @@ CODE
 # This file loads Spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
+# our nri environment is TOO DAMN LONG.
+# without this, we often get Argument List Too Long errors
+ENV.reject! { |key, _| key.start_with?("NIX_") || key.start_with?("DIRENV_") || key == "PYTHONPATH" }
+
 unless defined?(Spring)
   require 'rubygems'
   require 'bundler'


### PR DESCRIPTION
another approach for https://github.com/NoRedInk/spring/pull/1

should outfox https://github.com/rails/spring/issues/626

paired with @BrianHicks 


when we have a big environment, we sometimes get "argument list too long errors"

how to repro:

1. add a really long environmental variable prefixed with `NIX_`
2. in one terminal, run `spring server` (so you can easily see debug info, there's another way but you have to read the docs for that one)
3. in another terminal run, `rails c`

without this binstub: argument errors!!!
with this binstub: no errors, your life is a good life full of meaning